### PR TITLE
Allow input field to grow vertically as user types

### DIFF
--- a/src/TemplateApplication/MessageInputView.swift
+++ b/src/TemplateApplication/MessageInputView.swift
@@ -44,11 +44,12 @@ struct MessageInputView: View {
 
     var body: some View {
         HStack {
-            TextField(isQuerying ? "HealthGPT is thinking 🤔..." : "Type a message...", text: $userMessage)
+            TextField(isQuerying ? "HealthGPT is thinking 🤔..." : "Type a message...", text: $userMessage, axis: .vertical)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
                 .background(Color(.systemGray6))
                 .cornerRadius(10)
+                .lineLimit(1...5)
                 .disabled(isQuerying == true)
 
             Button(action: {


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Allow input field to grow vertically as user types

Allow the input field to increase in size vertically as the user types, up to 5 lines. After 5 lines, it will scroll. This makes it easier to enter longer queries.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

