### PR TITLE
Allow user to select model during onboarding

### DIFF
--- a/HealthGPT.xcodeproj/project.pbxproj
+++ b/HealthGPT.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27051AA929F727B10010211A /* ModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27051AA829F727B10010211A /* ModelSelection.swift */; };
 		2719BC7829F0A31500995C31 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2719BC7729F0A31500995C31 /* SettingsView.swift */; };
 		2719BC7A29F0A57D00995C31 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2719BC7929F0A57D00995C31 /* ChatView.swift */; };
 		2719BC7C29F0A59800995C31 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2719BC7B29F0A59800995C31 /* MessageView.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		27051AA829F727B10010211A /* ModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSelection.swift; sourceTree = "<group>"; };
 		2719BC7729F0A31500995C31 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		2719BC7929F0A57D00995C31 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		2719BC7B29F0A59800995C31 /* MessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				275DEFDA29EEC6CA0079D453 /* String+ModuleLocalized.swift */,
 				275DEFDC29EEC6DC0079D453 /* Welcome.swift */,
 				2719BC8129F150E900995C31 /* ApiKey.swift */,
+				27051AA829F727B10010211A /* ModelSelection.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				2719BC7A29F0A57D00995C31 /* ChatView.swift in Sources */,
 				275DEFF429EECA180079D453 /* CodableArray+RawRepresentable.swift in Sources */,
+				27051AA929F727B10010211A /* ModelSelection.swift in Sources */,
 				2719BC8229F150E900995C31 /* ApiKey.swift in Sources */,
 				2719BC7829F0A31500995C31 /* SettingsView.swift in Sources */,
 				E21D86A429EDB21B00490C26 /* MessageInputView.swift in Sources */,

--- a/HealthGPT.xcodeproj/xcshareddata/xcschemes/HealthGPT.xcscheme
+++ b/HealthGPT.xcodeproj/xcshareddata/xcschemes/HealthGPT.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "653A254C283387FE005D4D48"
+               BuildableName = "HealthGPT.app"
+               BlueprintName = "HealthGPT"
+               ReferencedContainer = "container:HealthGPT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F4E21D429F0518B0067EE98"
+               BuildableName = "HealthGPTUITests.xctest"
+               BlueprintName = "HealthGPTUITests"
+               ReferencedContainer = "container:HealthGPT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "653A254C283387FE005D4D48"
+            BuildableName = "HealthGPT.app"
+            BlueprintName = "HealthGPT"
+            ReferencedContainer = "container:HealthGPT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "653A254C283387FE005D4D48"
+            BuildableName = "HealthGPT.app"
+            BlueprintName = "HealthGPT"
+            ReferencedContainer = "container:HealthGPT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HealthGPT/HealthGPT/MessageInputView.swift
+++ b/HealthGPT/HealthGPT/MessageInputView.swift
@@ -13,6 +13,7 @@ struct MessageInputView: View {
     @Binding var userMessage: String
     @Binding var messages: [Message]
     @EnvironmentObject var secureStorage: SecureStorage<FHIR>
+    @AppStorage(StorageKeys.openAIModel) var openAIModel = Model.gpt3_5Turbo
 
     @State private var isQuerying = false
     @State private var showingSheet = false
@@ -166,7 +167,7 @@ struct MessageInputView: View {
                                     currentChat.append(.init(role: .user, content: userMessageToQuery))
 
                                     // if you have access to GPT-4, you can change `model` to `.gpt4` below
-                                    let query = ChatQuery(model: .gpt3_5Turbo, messages: currentChat)
+                                    let query = ChatQuery(model: openAIModel, messages: currentChat)
                                     let botMessageContent = try await openAI.chats(query: query).choices[0].message.content
 
                                     messages.append(Message(content: botMessageContent, isBot: true))

--- a/HealthGPT/HealthGPT/MessageInputView.swift
+++ b/HealthGPT/HealthGPT/MessageInputView.swift
@@ -166,7 +166,6 @@ struct MessageInputView: View {
                                     }
                                     currentChat.append(.init(role: .user, content: userMessageToQuery))
 
-                                    // if you have access to GPT-4, you can change `model` to `.gpt4` below
                                     let query = ChatQuery(model: openAIModel, messages: currentChat)
                                     let botMessageContent = try await openAI.chats(query: query).choices[0].message.content
 

--- a/HealthGPT/Onboarding/ApiKey.swift
+++ b/HealthGPT/Onboarding/ApiKey.swift
@@ -65,7 +65,7 @@ struct ApiKey: View {
                                 server: "openai.com",
                                 storageScope: .keychain
                             )
-                            onboardingSteps.append(.healthKitPermissions)
+                            onboardingSteps.append(.modelSelection)
                         } catch {
                             print("Error when storing API Key.")
                         }

--- a/HealthGPT/Onboarding/ModelSelection.swift
+++ b/HealthGPT/Onboarding/ModelSelection.swift
@@ -1,0 +1,60 @@
+//
+// This source file is part of the Stanford HealthGPT project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
+//
+
+import CardinalKitOnboarding
+import OpenAI
+import SwiftUI
+
+
+struct ModelSelection: View {
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
+    @AppStorage(StorageKeys.openAIModel) var openAIModel = Model.gpt3_5Turbo
+    @Binding private var onboardingSteps: [OnboardingFlow.Step]
+    @State private var selectedModel: Model = .gpt3_5Turbo
+
+
+    var body: some View {
+        OnboardingView(
+            titleView: {
+                OnboardingTitleView(
+                    title: "MODEL_SELECTION_TITLE".moduleLocalized,
+                    subtitle: "MODEL_SELECTION_SUBTITLE".moduleLocalized
+                )
+            },
+            contentView: {
+                Picker("Select OpenAI Model", selection: $selectedModel) {
+                    Text("GPT 3.5 Turbo").tag(Model.gpt3_5Turbo)
+                    Text("GPT 4").tag(Model.gpt4)
+                }
+                .pickerStyle(MenuPickerStyle())
+            },
+            actionView: {
+                OnboardingActionsView(
+                    "Save",
+                    action: {
+                        openAIModel = self.selectedModel
+                        onboardingSteps.append(.healthKitPermissions)
+                    }
+                )
+            }
+        )
+    }
+
+    init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
+        self._onboardingSteps = onboardingSteps
+    }
+}
+
+#if DEBUG
+struct ModelSelection_Previews: PreviewProvider {
+    @State private static var path: [OnboardingFlow.Step] = []
+
+
+    static var previews: some View {
+        ModelSelection(onboardingSteps: $path)
+    }
+}
+#endif

--- a/HealthGPT/Onboarding/ModelSelection.swift
+++ b/HealthGPT/Onboarding/ModelSelection.swift
@@ -10,12 +10,11 @@ import SwiftUI
 
 
 struct ModelSelection: View {
-    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
-    @AppStorage(StorageKeys.openAIModel) var openAIModel = Model.gpt3_5Turbo
+    @AppStorage(StorageKeys.openAIModel) private var openAIModel = Model.gpt3_5Turbo
     @Binding private var onboardingSteps: [OnboardingFlow.Step]
     @State private var selectedModel: Model = .gpt3_5Turbo
-
-
+    
+    
     var body: some View {
         OnboardingView(
             titleView: {
@@ -26,11 +25,13 @@ struct ModelSelection: View {
             },
             contentView: {
                 Picker("Select OpenAI Model", selection: $selectedModel) {
-                    Text("GPT 3.5 Turbo").tag(Model.gpt3_5Turbo)
-                    Text("GPT 4").tag(Model.gpt4)
+                    Text("GPT 3.5 Turbo")
+                        .tag(Model.gpt3_5Turbo)
+                    Text("GPT 4")
+                        .tag(Model.gpt4)
                 }
-                .pickerStyle(WheelPickerStyle())
-                .accessibilityIdentifier("modelPicker")
+                    .pickerStyle(.wheel)
+                    .accessibilityIdentifier("modelPicker")
             },
             actionView: {
                 OnboardingActionsView(
@@ -43,17 +44,19 @@ struct ModelSelection: View {
             }
         )
     }
-
+    
+    
     init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
         self._onboardingSteps = onboardingSteps
     }
 }
 
+
 #if DEBUG
 struct ModelSelection_Previews: PreviewProvider {
     @State private static var path: [OnboardingFlow.Step] = []
-
-
+    
+    
     static var previews: some View {
         ModelSelection(onboardingSteps: $path)
     }

--- a/HealthGPT/Onboarding/ModelSelection.swift
+++ b/HealthGPT/Onboarding/ModelSelection.swift
@@ -29,7 +29,8 @@ struct ModelSelection: View {
                     Text("GPT 3.5 Turbo").tag(Model.gpt3_5Turbo)
                     Text("GPT 4").tag(Model.gpt4)
                 }
-                .pickerStyle(MenuPickerStyle())
+                .pickerStyle(WheelPickerStyle())
+                .accessibilityIdentifier("modelPicker")
             },
             actionView: {
                 OnboardingActionsView(

--- a/HealthGPT/Onboarding/OnboardingFlow.swift
+++ b/HealthGPT/Onboarding/OnboardingFlow.swift
@@ -11,9 +11,9 @@ import SwiftUI
 struct OnboardingFlow: View {
     enum Step: String, Codable {
         case disclaimer
-        case healthKitPermissions
         case apiKey
         case modelSelection
+        case healthKitPermissions
     }
 
     @SceneStorage(StorageKeys.onboardingFlowStep) private var onboardingSteps: [Step] = []
@@ -25,14 +25,14 @@ struct OnboardingFlow: View {
             Welcome(onboardingSteps: $onboardingSteps)
                 .navigationDestination(for: Step.self) { onboardingStep in
                     switch onboardingStep {
-                    case .apiKey:
-                        ApiKey(onboardingSteps: $onboardingSteps)
                     case .disclaimer:
                         Disclaimer(onboardingSteps: $onboardingSteps)
-                    case .healthKitPermissions:
-                        HealthKitPermissions()
+                    case .apiKey:
+                        ApiKey(onboardingSteps: $onboardingSteps)
                     case .modelSelection:
                         ModelSelection(onboardingSteps: $onboardingSteps)
+                    case .healthKitPermissions:
+                        HealthKitPermissions()
                     }
                 }
                 .navigationBarTitleDisplayMode(.inline)

--- a/HealthGPT/Onboarding/OnboardingFlow.swift
+++ b/HealthGPT/Onboarding/OnboardingFlow.swift
@@ -13,6 +13,7 @@ struct OnboardingFlow: View {
         case disclaimer
         case healthKitPermissions
         case apiKey
+        case modelSelection
     }
 
     @SceneStorage(StorageKeys.onboardingFlowStep) private var onboardingSteps: [Step] = []
@@ -30,6 +31,8 @@ struct OnboardingFlow: View {
                         Disclaimer(onboardingSteps: $onboardingSteps)
                     case .healthKitPermissions:
                         HealthKitPermissions()
+                    case .modelSelection:
+                        ModelSelection(onboardingSteps: $onboardingSteps)
                     }
                 }
                 .navigationBarTitleDisplayMode(.inline)

--- a/HealthGPT/SharedContext/StorageKeys.swift
+++ b/HealthGPT/SharedContext/StorageKeys.swift
@@ -13,4 +13,6 @@ enum StorageKeys {
     static let onboardingFlowComplete = "onboardingFlow.complete"
     /// A `Step` flag indicating the current step in the onboarding process.
     static let onboardingFlowStep = "onboardingFlow.step"
+    /// An `AIModel` flag indicating the OpenAI model to use
+    static let openAIModel = "openAI.model"
 }

--- a/HealthGPT/Supporting Files/Localizable.strings
+++ b/HealthGPT/Supporting Files/Localizable.strings
@@ -50,3 +50,7 @@
 // MARK: API Key
 "API_KEY_TITLE" = "OpenAI API Key";
 "API_KEY_SUBTITLE" = "Please copy and paste your API key into the box below.";
+
+// MARK: Model Selection
+"MODEL_SELECTION_TITLE" = "Select an OpenAI Model";
+"MODEL_SELECTION_SUBTITLE" = "If you have access to GPT4, you may select it below.";

--- a/HealthGPT/Supporting Files/Localizable.strings
+++ b/HealthGPT/Supporting Files/Localizable.strings
@@ -53,4 +53,4 @@
 
 // MARK: Model Selection
 "MODEL_SELECTION_TITLE" = "Select an OpenAI Model";
-"MODEL_SELECTION_SUBTITLE" = "If you have access to GPT4, you may select it below.";
+"MODEL_SELECTION_SUBTITLE" = "If you have access to GPT4, you may select it below. Otherwise select GPT 3.5 Turbo.";

--- a/HealthGPTUITests/HealthGPTUITests.swift
+++ b/HealthGPTUITests/HealthGPTUITests.swift
@@ -45,6 +45,7 @@ extension XCUIApplication {
         try navigateOnboardingFlowWelcome()
         try navigateOnboardingFlowDisclaimer()
         try navigateOnboardingFlowApiKey()
+        try navigateOnboardingFlowModelSelection()
         try navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: assertThatHealthKitConsentIsShown)
     }
 
@@ -76,6 +77,17 @@ extension XCUIApplication {
 
         XCTAssertTrue(buttons["Save API Key"].isEnabled, "The button should be enabled if text has been entered.")
         buttons["Save API Key"].tap()
+    }
+
+    private func navigateOnboardingFlowModelSelection() throws {
+        XCTAssertTrue(staticTexts["Select an OpenAI Model"].waitForExistence(timeout: 2))
+        XCTAssertTrue(buttons["Save"].waitForExistence(timeout: 2))
+
+        let picker = pickers["modelPicker"]
+        let optionToSelect = picker.pickerWheels.element(boundBy: 0)
+        optionToSelect.adjust(toPickerWheelValue: "GPT 4")
+
+        buttons["Save"].tap()
     }
 
     private func navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: Bool = true) throws {


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Allow user to select model during onboarding

## :recycle: Current situation & Problem
Currently the user doesn't have the option to select the OpenAI model they want to use from within the app. They need to edit the code directly. 

## :bulb: Proposed solution
Adds a step to onboarding, after the API key entry, that allows the user to select whether they want to use *GPT 3.5 Turbo* or *GPT 4* (if they have access).

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

