### PR TITLE
Adds MIT license and REUSE compliance check

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,9 @@ jobs:
     with:
       artifactname: HealthGPT.xcresult
       fastlanelane: test
+  reuse_action:
+    name: REUSE Compliance Check
+    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
     uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2

--- a/HealthGPT/HealthGPT/ChatView.swift
+++ b/HealthGPT/HealthGPT/ChatView.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/HealthGPT/HealthDataFetcher.swift
+++ b/HealthGPT/HealthGPT/HealthDataFetcher.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import HealthKit
 

--- a/HealthGPT/HealthGPT/HealthGPTView.swift
+++ b/HealthGPT/HealthGPT/HealthGPTView.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import HealthKit
 import OpenAI

--- a/HealthGPT/HealthGPT/Message.swift
+++ b/HealthGPT/HealthGPT/Message.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import Foundation
 

--- a/HealthGPT/HealthGPT/MessageInputView.swift
+++ b/HealthGPT/HealthGPT/MessageInputView.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitFHIR
 import CardinalKitSecureStorage

--- a/HealthGPT/HealthGPT/MessageView.swift
+++ b/HealthGPT/HealthGPT/MessageView.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/HealthGPT/SettingsView.swift
+++ b/HealthGPT/HealthGPT/SettingsView.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/HealthGPT/UIApplication+Keyboard.swift
+++ b/HealthGPT/HealthGPT/UIApplication+Keyboard.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/Helper/Binding+Negate.swift
+++ b/HealthGPT/Helper/Binding+Negate.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/Helper/CodableArray+RawRepresentable.swift
+++ b/HealthGPT/Helper/CodableArray+RawRepresentable.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import Foundation
 

--- a/HealthGPT/Home.swift
+++ b/HealthGPT/Home.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/Onboarding/ApiKey.swift
+++ b/HealthGPT/Onboarding/ApiKey.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitFHIR
 import CardinalKitOnboarding

--- a/HealthGPT/Onboarding/Disclaimer.swift
+++ b/HealthGPT/Onboarding/Disclaimer.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitFHIR
 import CardinalKitOnboarding

--- a/HealthGPT/Onboarding/HealthKitPermissions.swift
+++ b/HealthGPT/Onboarding/HealthKitPermissions.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitFHIR
 import CardinalKitHealthKit

--- a/HealthGPT/Onboarding/ModelSelection.swift
+++ b/HealthGPT/Onboarding/ModelSelection.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitOnboarding
 import OpenAI

--- a/HealthGPT/Onboarding/OnboardingFlow.swift
+++ b/HealthGPT/Onboarding/OnboardingFlow.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import SwiftUI
 

--- a/HealthGPT/Onboarding/String+ModuleLocalized.swift
+++ b/HealthGPT/Onboarding/String+ModuleLocalized.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 extension String {
     var moduleLocalized: String {

--- a/HealthGPT/Onboarding/Welcome.swift
+++ b/HealthGPT/Onboarding/Welcome.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKitOnboarding
 import SwiftUI

--- a/HealthGPT/SharedContext/FeatureFlags.swift
+++ b/HealthGPT/SharedContext/FeatureFlags.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 /// A collection of feature flags for the HealthGPT app.
 enum FeatureFlags {

--- a/HealthGPT/SharedContext/StorageKeys.swift
+++ b/HealthGPT/SharedContext/StorageKeys.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 
 /// Constants shared across the CardinalKit Teamplate Application to access

--- a/HealthGPT/TemplateAppDelegate.swift
+++ b/HealthGPT/TemplateAppDelegate.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKit
 import CardinalKitFHIR

--- a/HealthGPT/TemplateAppTestingSetup.swift
+++ b/HealthGPT/TemplateAppTestingSetup.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import Security
 import SwiftUI

--- a/HealthGPT/TemplateApplication.swift
+++ b/HealthGPT/TemplateApplication.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import CardinalKit
 import SwiftUI

--- a/HealthGPTUITests/HealthGPTUITests.swift
+++ b/HealthGPTUITests/HealthGPTUITests.swift
@@ -3,6 +3,8 @@
 //
 // SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors
 //
+// SPDX-License-Identifier: MIT
+//
 
 import XCTest
 import XCTestExtensions

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds MIT license and REUSE compliance check

Adds the MIT license and a Github actions workflow to check for compliance with the [REUSE specification](https://reuse.software/spec/), a standardized method for declaring copyright and licensing information for all @StanfordBDGH projects.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

