### PR TITLE
Stream responses from model

### DIFF
--- a/HealthGPT.xcodeproj/project.pbxproj
+++ b/HealthGPT.xcodeproj/project.pbxproj
@@ -1064,7 +1064,7 @@
 			repositoryURL = "https://github.com/MacPaw/OpenAI.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.2;
+				minimumVersion = 0.2.1;
 			};
 		};
 		2FF8DBF529F041F200239E1A /* XCRemoteSwiftPackageReference "CardinalKitFHIR" */ = {

--- a/HealthGPT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HealthGPT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI.git",
       "state" : {
-        "revision" : "65748811327527fad88a1a0d141911fd6072b720",
-        "version" : "0.1.2"
+        "revision" : "4da423fe637a628ebee8f214217a9e96060a5222",
+        "version" : "0.2.1"
       }
     },
     {

--- a/HealthGPT/HealthGPT/Message.swift
+++ b/HealthGPT/HealthGPT/Message.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct Message: Identifiable {
-    var id = UUID()
+    var id: String = UUID().uuidString
     var content: String
     var isBot: Bool
 }

--- a/HealthGPT/HealthGPT/OpenAIManager.swift
+++ b/HealthGPT/HealthGPT/OpenAIManager.swift
@@ -36,12 +36,11 @@ class OpenAIManager {
     ///   - messages: The array of messages used in the conversation.
     ///
     /// - Returns: The content of the response from the API.
-    func queryAPI(mainPrompt: String, messages: [Message]) async throws -> String {
+    func queryAPI(mainPrompt: String, messages: [Message]) async throws -> AsyncThrowingStream<ChatStreamResult, Error> {
         guard let apiToken, !apiToken.isEmpty else {
             throw OpenAIAPIError.noAPIToken
         }
 
-        let openAI = OpenAI(apiToken: apiToken)
         var currentChat: [Chat] = [.init(role: .system, content: mainPrompt)]
 
         for message in messages {
@@ -53,9 +52,9 @@ class OpenAIManager {
             )
         }
 
+        let openAIClient = OpenAI(apiToken: apiToken)
         let query = ChatQuery(model: openAIModel, messages: currentChat)
-        let botMessageContent = try await openAI.chats(query: query).choices[0].message.content
-        return botMessageContent
+        return openAIClient.chatsStream(query: query)
     }
 
     /// Updates the API token for the OpenAI API.


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Stream responses from model

## :recycle: Current situation & Problem
Currently we wait until receiving a complete response from the model in order to display it to the user. If the response takes a long time to generate, the user has to wait.

## :bulb: Proposed solution
This PR allows for streaming the response from the model as it is generated using an `AsyncThrowingStream` which is supported in the [MacPaw/OpenAI](https://github.com/MacPaw/OpenAI) package as of release 0.2.0.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

