### PR TITLE
Update HealthGPT to Spezi 0.7

### DIFF
--- a/HealthGPT.xcodeproj/project.pbxproj
+++ b/HealthGPT.xcodeproj/project.pbxproj
@@ -27,8 +27,6 @@
 		27859C012A34F15E00397C85 /* XCTSpezi in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C002A34F15E00397C85 /* XCTSpezi */; };
 		27859C042A34F16B00397C85 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C032A34F16B00397C85 /* SpeziHealthKit */; };
 		27859C072A34F17800397C85 /* SpeziOnboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C062A34F17800397C85 /* SpeziOnboarding */; };
-		27859C0A2A34F18900397C85 /* SpeziFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C092A34F18900397C85 /* SpeziFHIR */; };
-		27859C0D2A34F19900397C85 /* SpeziHealthKitToFHIRAdapter in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C0C2A34F19900397C85 /* SpeziHealthKitToFHIRAdapter */; };
 		27859C102A34F1A900397C85 /* SpeziLocalStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C0F2A34F1A900397C85 /* SpeziLocalStorage */; };
 		27859C122A34F1A900397C85 /* SpeziSecureStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C112A34F1A900397C85 /* SpeziSecureStorage */; };
 		27859C202A34F2BF00397C85 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C1F2A34F2BF00397C85 /* XCTestApp */; };
@@ -37,6 +35,9 @@
 		27859C282A34F2DE00397C85 /* XCTRuntimeAssertions in Frameworks */ = {isa = PBXBuildFile; productRef = 27859C272A34F2DE00397C85 /* XCTRuntimeAssertions */; };
 		27B249672A065D360091E52C /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B249662A065D360091E52C /* PromptGeneratorTests.swift */; };
 		27BA6BE429EF9A910079DC17 /* OpenAI-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 27BA6BE329EF9A910079DC17 /* OpenAI-Info.plist */; };
+		2F4242952A8B0393006E2B01 /* OpenAIAPIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4242942A8B0393006E2B01 /* OpenAIAPIKey.swift */; };
+		2F4242972A8B03A5006E2B01 /* OpenAIModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4242962A8B03A5006E2B01 /* OpenAIModelSelection.swift */; };
+		2F4242992A8B0432006E2B01 /* HealthGPTStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4242982A8B0432006E2B01 /* HealthGPTStandard.swift */; };
 		2F4E21D829F0518B0067EE98 /* HealthGPTUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E21D729F0518B0067EE98 /* HealthGPTUITests.swift */; };
 		2F4E23832989D51F0013F3D9 /* HealthGPTAppTestingSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23822989D51F0013F3D9 /* HealthGPTAppTestingSetup.swift */; };
 		2F5E32BD297E05EA003432F8 /* HealthGPTAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5E32BC297E05EA003432F8 /* HealthGPTAppDelegate.swift */; };
@@ -88,6 +89,9 @@
 		27B2495A2A06590E0091E52C /* HealthGPTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HealthGPTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		27B249662A065D360091E52C /* PromptGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptGeneratorTests.swift; sourceTree = "<group>"; };
 		27BA6BE329EF9A910079DC17 /* OpenAI-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OpenAI-Info.plist"; sourceTree = "<group>"; };
+		2F4242942A8B0393006E2B01 /* OpenAIAPIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIAPIKey.swift; sourceTree = "<group>"; };
+		2F4242962A8B03A5006E2B01 /* OpenAIModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIModelSelection.swift; sourceTree = "<group>"; };
+		2F4242982A8B0432006E2B01 /* HealthGPTStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthGPTStandard.swift; sourceTree = "<group>"; };
 		2F4E21D529F0518B0067EE98 /* HealthGPTUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HealthGPTUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F4E21D729F0518B0067EE98 /* HealthGPTUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthGPTUITests.swift; sourceTree = "<group>"; };
 		2F4E23822989D51F0013F3D9 /* HealthGPTAppTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthGPTAppTestingSetup.swift; sourceTree = "<group>"; };
@@ -134,9 +138,7 @@
 				27859BFF2A34F15E00397C85 /* Spezi in Frameworks */,
 				4A0549192A48088600F316A2 /* SpeziOpenAI in Frameworks */,
 				27859C102A34F1A900397C85 /* SpeziLocalStorage in Frameworks */,
-				27859C0D2A34F19900397C85 /* SpeziHealthKitToFHIRAdapter in Frameworks */,
 				2FF8DBF429F041C500239E1A /* OpenAI in Frameworks */,
-				27859C0A2A34F18900397C85 /* SpeziFHIR in Frameworks */,
 				27859C122A34F1A900397C85 /* SpeziSecureStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -158,6 +160,8 @@
 			children = (
 				275DEFD629EEC6A60079D453 /* Disclaimer.swift */,
 				275DEFD429EEC6870079D453 /* HealthKitPermissions.swift */,
+				2F4242942A8B0393006E2B01 /* OpenAIAPIKey.swift */,
+				2F4242962A8B03A5006E2B01 /* OpenAIModelSelection.swift */,
 				275DEFD829EEC6B80079D453 /* OnboardingFlow.swift */,
 				275DEFDA29EEC6CA0079D453 /* String+ModuleLocalized.swift */,
 				275DEFDC29EEC6DC0079D453 /* Welcome.swift */,
@@ -251,6 +255,7 @@
 				2FC9759D2978E30800BA99FE /* Supporting Files */,
 				2F5E32BC297E05EA003432F8 /* HealthGPTAppDelegate.swift */,
 				653A2550283387FE005D4D48 /* HealthGPTApplication.swift */,
+				2F4242982A8B0432006E2B01 /* HealthGPTStandard.swift */,
 				2F4E23822989D51F0013F3D9 /* HealthGPTAppTestingSetup.swift */,
 			);
 			path = HealthGPT;
@@ -329,8 +334,6 @@
 				27859C002A34F15E00397C85 /* XCTSpezi */,
 				27859C032A34F16B00397C85 /* SpeziHealthKit */,
 				27859C062A34F17800397C85 /* SpeziOnboarding */,
-				27859C092A34F18900397C85 /* SpeziFHIR */,
-				27859C0C2A34F19900397C85 /* SpeziHealthKitToFHIRAdapter */,
 				27859C0F2A34F1A900397C85 /* SpeziLocalStorage */,
 				27859C112A34F1A900397C85 /* SpeziSecureStorage */,
 				4A0549182A48088600F316A2 /* SpeziOpenAI */,
@@ -376,8 +379,6 @@
 				27859BFD2A34F15E00397C85 /* XCRemoteSwiftPackageReference "Spezi" */,
 				27859C022A34F16A00397C85 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 				27859C052A34F17800397C85 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */,
-				27859C082A34F18900397C85 /* XCRemoteSwiftPackageReference "SpeziFHIR" */,
-				27859C0B2A34F19900397C85 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */,
 				27859C0E2A34F1A900397C85 /* XCRemoteSwiftPackageReference "SpeziStorage" */,
 				27859C1E2A34F2BF00397C85 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 				27859C232A34F2D000397C85 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
@@ -470,6 +471,8 @@
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				275DEFF429EECA180079D453 /* CodableArray+RawRepresentable.swift in Sources */,
 				2719BC7829F0A31500995C31 /* SettingsView.swift in Sources */,
+				2F4242992A8B0432006E2B01 /* HealthGPTStandard.swift in Sources */,
+				2F4242972A8B03A5006E2B01 /* OpenAIModelSelection.swift in Sources */,
 				2F4E23832989D51F0013F3D9 /* HealthGPTAppTestingSetup.swift in Sources */,
 				272FB34E2A03CDFF0010B98D /* HealthDataFetcher+Process.swift in Sources */,
 				275DEFD029EEC5D20079D453 /* FeatureFlags.swift in Sources */,
@@ -484,6 +487,7 @@
 				E22B62EF29E8CE1E008F3484 /* HealthGPTView.swift in Sources */,
 				275DEFCE29EEC5AD0079D453 /* StorageKeys.swift in Sources */,
 				272FB3502A03D1000010B98D /* HealthDataFetcherError.swift in Sources */,
+				2F4242952A8B0393006E2B01 /* OpenAIAPIKey.swift in Sources */,
 				272FB3562A0401130010B98D /* Date+Extensions.swift in Sources */,
 				653A2551283387FE005D4D48 /* HealthGPTApplication.swift in Sources */,
 				E21D86A029EDB17500490C26 /* HealthDataFetcher.swift in Sources */,
@@ -980,7 +984,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.3;
+				minimumVersion = 0.7.1;
 			};
 		};
 		27859C022A34F16A00397C85 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
@@ -988,7 +992,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.1;
+				minimumVersion = 0.3.1;
 			};
 		};
 		27859C052A34F17800397C85 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */ = {
@@ -996,23 +1000,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziOnboarding.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
-			};
-		};
-		27859C082A34F18900397C85 /* XCRemoteSwiftPackageReference "SpeziFHIR" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
-			};
-		};
-		27859C0B2A34F19900397C85 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKitToFHIRAdapter.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.4.2;
 			};
 		};
 		27859C0E2A34F1A900397C85 /* XCRemoteSwiftPackageReference "SpeziStorage" */ = {
@@ -1020,7 +1008,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziStorage.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.1;
+				minimumVersion = 0.4.1;
 			};
 		};
 		27859C1E2A34F2BF00397C85 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
@@ -1028,7 +1016,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.2;
+				minimumVersion = 0.4.6;
 			};
 		};
 		27859C232A34F2D000397C85 /* XCRemoteSwiftPackageReference "XCTHealthKit" */ = {
@@ -1036,7 +1024,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTHealthKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.3;
+				minimumVersion = 0.3.5;
 			};
 		};
 		27859C262A34F2DE00397C85 /* XCRemoteSwiftPackageReference "XCTRuntimeAssertions" */ = {
@@ -1044,7 +1032,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.3;
+				minimumVersion = 0.2.5;
 			};
 		};
 		2FF8DBF229F041C500239E1A /* XCRemoteSwiftPackageReference "OpenAI" */ = {
@@ -1052,15 +1040,15 @@
 			repositoryURL = "https://github.com/MacPaw/OpenAI.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.2.1;
+				minimumVersion = 0.2.3;
 			};
 		};
 		4A0549172A48088600F316A2 /* XCRemoteSwiftPackageReference "SpeziML" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziML.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.6;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1085,16 +1073,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 27859C052A34F17800397C85 /* XCRemoteSwiftPackageReference "SpeziOnboarding" */;
 			productName = SpeziOnboarding;
-		};
-		27859C092A34F18900397C85 /* SpeziFHIR */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 27859C082A34F18900397C85 /* XCRemoteSwiftPackageReference "SpeziFHIR" */;
-			productName = SpeziFHIR;
-		};
-		27859C0C2A34F19900397C85 /* SpeziHealthKitToFHIRAdapter */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 27859C0B2A34F19900397C85 /* XCRemoteSwiftPackageReference "SpeziHealthKitToFHIRAdapter" */;
-			productName = SpeziHealthKitToFHIRAdapter;
 		};
 		27859C0F2A34F1A900397C85 /* SpeziLocalStorage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/HealthGPT.xcodeproj/project.pbxproj
+++ b/HealthGPT.xcodeproj/project.pbxproj
@@ -691,7 +691,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "HealthGPT/Supporting Files/HealthGPT.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
@@ -850,7 +850,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "HealthGPT/Supporting Files/HealthGPT.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
@@ -895,10 +895,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "HealthGPT/Supporting Files/HealthGPT.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "HealthGPT/Supporting Files/Info.plist";
@@ -924,6 +926,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.bdhg.healthgpt;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = HealthGPT;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/HealthGPT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HealthGPT.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,24 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "fhirmodels",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/FHIRModels",
-      "state" : {
-        "revision" : "861afd5816a98d38f86220eab2f812d76cad84a0",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "healthkitonfhir",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR",
-      "state" : {
-        "revision" : "fdf8e4543718a940643598e4bd5e750e9c4c5540",
-        "version" : "0.2.4"
-      }
-    },
-    {
       "identity" : "openai",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MacPaw/OpenAI.git",
@@ -32,17 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi.git",
       "state" : {
-        "revision" : "cfcb4d81640f3b7794f36f47e70d72ccfa00f099",
-        "version" : "0.5.3"
-      }
-    },
-    {
-      "identity" : "spezifhir",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziFHIR.git",
-      "state" : {
-        "revision" : "6303e65ba339f89b86a6dc09aab243b50de33cd7",
-        "version" : "0.3.0"
+        "revision" : "9ad506d4d2e36eb7a0c1ff8cc6bb0ef9c972724c",
+        "version" : "0.7.1"
       }
     },
     {
@@ -50,17 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "0a26f415c90d586a2417f31b1444bb08e004db17",
-        "version" : "0.2.2"
-      }
-    },
-    {
-      "identity" : "spezihealthkittofhiradapter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziHealthKitToFHIRAdapter.git",
-      "state" : {
-        "revision" : "e43f2c05cebcd16a697397721e6a2d72bf418a9c",
-        "version" : "0.3.0"
+        "revision" : "f8f664549e81c8fa107a1fff616e0eaca6e8a6fa",
+        "version" : "0.3.1"
       }
     },
     {
@@ -68,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziML.git",
       "state" : {
-        "revision" : "190c7b2fda06c359bc650b73aa38bc9809ade422",
-        "version" : "0.1.8"
+        "revision" : "700ab5e524ec4f12f3012b514ea24822bdc6066b",
+        "version" : "0.2.2"
       }
     },
     {
@@ -77,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziOnboarding.git",
       "state" : {
-        "revision" : "a84ddd7cdb5ce48935ca3daf2a33ddc512d76b33",
-        "version" : "0.3.1"
+        "revision" : "8e84137a08510f051d93cca546fdce3acb67e012",
+        "version" : "0.4.2"
       }
     },
     {
@@ -86,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziStorage.git",
       "state" : {
-        "revision" : "5dc128a257a6b4f7d2f4d96803c0cf89238bb922",
-        "version" : "0.3.1"
+        "revision" : "77666f57cc0b7f148bc3949f173db8498ef9b4a6",
+        "version" : "0.4.1"
       }
     },
     {
@@ -95,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews",
       "state" : {
-        "revision" : "c6975e84c735b8b8a13740012c1c194f48893fa8",
-        "version" : "0.3.0"
+        "revision" : "3131708f262064231751a8963eb263f8648b6879",
+        "version" : "0.4.1"
       }
     },
     {

--- a/HealthGPT/HealthGPT/HealthDataInterpreter.swift
+++ b/HealthGPT/HealthGPT/HealthDataInterpreter.swift
@@ -8,11 +8,10 @@
 
 import Foundation
 import Spezi
-import SpeziFHIR
 import SpeziOpenAI
 
 
-class HealthDataInterpreter<ComponentStandard: Standard>: DefaultInitializable, Component, ObservableObject, ObservableObjectProvider {
+class HealthDataInterpreter: DefaultInitializable, Component, ObservableObject, ObservableObjectProvider {
     @Dependency var openAIComponent = OpenAIComponent()
     
     

--- a/HealthGPT/HealthGPT/HealthGPTView.swift
+++ b/HealthGPT/HealthGPT/HealthGPTView.swift
@@ -6,15 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziFHIR
 import SpeziOpenAI
 import SwiftUI
 
 
 struct HealthGPTView: View {
     @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
-    @EnvironmentObject private var openAPIComponent: OpenAIComponent<FHIR>
-    @EnvironmentObject private var healthDataInterpreter: HealthDataInterpreter<FHIR>
+    @EnvironmentObject private var openAPIComponent: OpenAIComponent
+    @EnvironmentObject private var healthDataInterpreter: HealthDataInterpreter
     @State private var showSettings = false
     
     

--- a/HealthGPT/HealthGPTAppDelegate.swift
+++ b/HealthGPT/HealthGPTAppDelegate.swift
@@ -8,16 +8,14 @@
 
 import HealthKit
 import Spezi
-import SpeziFHIR
 import SpeziHealthKit
-import SpeziHealthKitToFHIRAdapter
 import SpeziOpenAI
 import SwiftUI
 
 
 class HealthGPTAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
-        Configuration(standard: FHIR()) {
+        Configuration(standard: HealthGPTStandard()) {
             OpenAIComponent()
             HealthDataInterpreter()
             if HKHealthStore.isHealthDataAvailable() {
@@ -27,7 +25,7 @@ class HealthGPTAppDelegate: SpeziAppDelegate {
     }
 
 
-    private var healthKit: HealthKit<FHIR> {
+    private var healthKit: HealthKit {
         HealthKit {
             CollectSamples(
                 [
@@ -40,8 +38,6 @@ class HealthGPTAppDelegate: SpeziAppDelegate {
                 ],
                 deliverySetting: .manual()
             )
-        } adapter: {
-            HealthKitToFHIRAdapter()
         }
     }
 }

--- a/HealthGPT/HealthGPTApplication.swift
+++ b/HealthGPT/HealthGPTApplication.swift
@@ -14,7 +14,8 @@ import SwiftUI
 struct HealthGPTApplication: App {
     @UIApplicationDelegateAdaptor(HealthGPTAppDelegate.self) var appDelegate
     @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
-
+    
+    
     var body: some Scene {
         WindowGroup {
             Group {

--- a/HealthGPT/HealthGPTStandard.swift
+++ b/HealthGPT/HealthGPTStandard.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the Stanford HealthGPT project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SpeziHealthKit
+
+
+actor HealthGPTStandard: Standard, ObservableObject, ObservableObjectProvider, HealthKitConstraint {
+    func add(sample: HKSample) async { }
+    func remove(sample: HKDeletedObject) async { }
+}

--- a/HealthGPT/Onboarding/Disclaimer.swift
+++ b/HealthGPT/Onboarding/Disclaimer.swift
@@ -6,14 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziFHIR
 import SpeziOnboarding
 import SwiftUI
 
 
 struct Disclaimer: View {
-    @Binding private var onboardingSteps: [OnboardingFlow.Step]
-
+    @EnvironmentObject private var onboardingNavigationPath: OnboardingNavigationPath
+    
+    
     var body: some View {
         SequentialOnboardingView(
             title: "INTERESTING_MODULES_TITLE".moduleLocalized,
@@ -38,25 +38,17 @@ struct Disclaimer: View {
             ],
             actionText: "INTERESTING_MODULES_BUTTON".moduleLocalized,
             action: {
-                onboardingSteps.append(.openAIAPIKey)
+                onboardingNavigationPath.nextStep()
             }
         )
-    }
-
-
-    init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
-        self._onboardingSteps = onboardingSteps
     }
 }
 
 
 #if DEBUG
 struct Disclaimer_Previews: PreviewProvider {
-    @State private static var path: [OnboardingFlow.Step] = []
-
-
     static var previews: some View {
-        Disclaimer(onboardingSteps: $path)
+        Disclaimer()
     }
 }
 #endif

--- a/HealthGPT/Onboarding/HealthKitPermissions.swift
+++ b/HealthGPT/Onboarding/HealthKitPermissions.swift
@@ -6,15 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziFHIR
 import SpeziHealthKit
 import SpeziOnboarding
 import SwiftUI
 
 
 struct HealthKitPermissions: View {
-    @EnvironmentObject var healthKitDataSource: HealthKit<FHIR>
-    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
+    @EnvironmentObject var healthKitDataSource: HealthKit
+    @EnvironmentObject private var onboardingNavigationPath: OnboardingNavigationPath
     @State var healthKitProcessing = false
 
 
@@ -50,7 +49,7 @@ struct HealthKitPermissions: View {
                         } catch {
                             print("Could not request HealthKit permissions.")
                         }
-                        completedOnboardingFlow = true
+                        onboardingNavigationPath.nextStep()
                         healthKitProcessing = false
                     }
                 )

--- a/HealthGPT/Onboarding/OnboardingFlow.swift
+++ b/HealthGPT/Onboarding/OnboardingFlow.swift
@@ -6,45 +6,29 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SpeziFHIR
+import HealthKit
+import SpeziOnboarding
 import SpeziOpenAI
 import SwiftUI
 
 
 /// Displays an multi-step onboarding flow for the HealthGPT Application.
 struct OnboardingFlow: View {
-    enum Step: String, Codable {
-        case disclaimer
-        case openAIAPIKey
-        case modelSelection
-        case healthKitPermissions
-    }
-
-    @SceneStorage(StorageKeys.onboardingFlowStep) private var onboardingSteps: [Step] = []
     @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
-
+    
+    
     var body: some View {
-        NavigationStack(path: $onboardingSteps) {
-            Welcome(onboardingSteps: $onboardingSteps)
-                .navigationDestination(for: Step.self) { onboardingStep in
-                    switch onboardingStep {
-                    case .disclaimer:
-                        Disclaimer(onboardingSteps: $onboardingSteps)
-                    case .openAIAPIKey:
-                        OpenAIAPIKeyOnboardingStep<FHIR> {
-                            onboardingSteps.append(.modelSelection)
-                        }
-                    case .modelSelection:
-                        OpenAIModelSelectionOnboardingStep<FHIR> {
-                            onboardingSteps.append(.healthKitPermissions)
-                        }
-                    case .healthKitPermissions:
-                        HealthKitPermissions()
-                    }
-                }
-                .navigationBarTitleDisplayMode(.inline)
+        OnboardingStack(onboardingFlowComplete: $completedOnboardingFlow) {
+            Welcome()
+            Disclaimer()
+            OpenAIAPIKey()
+            OpenAIModelSelection()
+            if HKHealthStore.isHealthDataAvailable() {
+                HealthKitPermissions()
+            }
         }
-        .interactiveDismissDisabled(!completedOnboardingFlow)
+            .navigationBarTitleDisplayMode(.inline)
+            .interactiveDismissDisabled(!completedOnboardingFlow)
     }
 }
 

--- a/HealthGPT/Onboarding/OpenAIAPIKey.swift
+++ b/HealthGPT/Onboarding/OpenAIAPIKey.swift
@@ -1,0 +1,23 @@
+//
+// This source file is part of the Stanford HealthGPT project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziOnboarding
+import SpeziOpenAI
+import SwiftUI
+
+
+struct OpenAIAPIKey: View {
+    @EnvironmentObject private var onboardingNavigationPath: OnboardingNavigationPath
+    
+    
+    var body: some View {
+        OpenAIAPIKeyOnboardingStep {
+            onboardingNavigationPath.nextStep()
+        }
+    }
+}

--- a/HealthGPT/Onboarding/OpenAIModelSelection.swift
+++ b/HealthGPT/Onboarding/OpenAIModelSelection.swift
@@ -1,0 +1,23 @@
+//
+// This source file is part of the Stanford HealthGPT project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziOnboarding
+import SpeziOpenAI
+import SwiftUI
+
+
+struct OpenAIModelSelection: View {
+    @EnvironmentObject private var onboardingNavigationPath: OnboardingNavigationPath
+    
+    
+    var body: some View {
+        OpenAIModelSelectionOnboardingStep {
+            onboardingNavigationPath.nextStep()
+        }
+    }
+}

--- a/HealthGPT/Onboarding/Welcome.swift
+++ b/HealthGPT/Onboarding/Welcome.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 struct Welcome: View {
-    @Binding private var onboardingSteps: [OnboardingFlow.Step]
+    @EnvironmentObject private var onboardingNavigationPath: OnboardingNavigationPath
 
 
     var body: some View {
@@ -37,25 +37,17 @@ struct Welcome: View {
             ],
             actionText: "WELCOME_BUTTON".moduleLocalized,
             action: {
-                onboardingSteps.append(.disclaimer)
+                onboardingNavigationPath.nextStep()
             }
         )
-    }
-
-
-    init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
-        self._onboardingSteps = onboardingSteps
     }
 }
 
 
 #if DEBUG
 struct Welcome_Previews: PreviewProvider {
-    @State private static var path: [OnboardingFlow.Step] = []
-
-
     static var previews: some View {
-        Welcome(onboardingSteps: $path)
+        Welcome()
     }
 }
 #endif


### PR DESCRIPTION
# Update HealthGPT to Spezi 0.7

## :recycle: Current situation & Problem
- HealthGPT has been using an older version of Spezi.
- A bug in SpeziML prevented the sending of messages.
- The signing setup in the CI was broking due to changes in previous PRs.

## :bulb: Proposed solution
- Updates to the latest version of Spezi (0.7.1) and SpeziML (0.2.2).
- Fix smaller configuration issues.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

