### PR TITLE
Add missing .restingHeartRate HealthKit permission

### DIFF
--- a/HealthGPT/HealthGPTAppDelegate.swift
+++ b/HealthGPT/HealthGPTAppDelegate.swift
@@ -46,6 +46,7 @@ class HealthGPTAppDelegate: SpeziAppDelegate {
                         .appleExerciseTime,
                         .bodyMass,
                         .heartRate,
+                    .restingHeartRate,
                         .stepCount
                     ]
             )

--- a/HealthGPT/HealthGPTAppDelegate.swift
+++ b/HealthGPT/HealthGPTAppDelegate.swift
@@ -46,7 +46,7 @@ class HealthGPTAppDelegate: SpeziAppDelegate {
                         .appleExerciseTime,
                         .bodyMass,
                         .heartRate,
-                    .restingHeartRate,
+                        .restingHeartRate,
                         .stepCount
                     ]
             )


### PR DESCRIPTION
  ## :recycle: Current situation & Problem

  The app requests HealthKit read permission for `.heartRate` but queries       
  `.restingHeartRate` in `HealthDataFetcher`. These are distinct
  `HKQuantityTypeIdentifier` values, so HealthKit silently returns no data for  
  resting heart rate, and all days report 0 bpm.

  Resolves #56 


  ## :gear: Release Notes

  - Adds `.restingHeartRate` to the HealthKit `RequestReadAccess` quantity array
   so the fetcher can retrieve resting heart rate data


  ## :books: Documentation

  No documentation changes needed. This is a one-line permission fix in
  `HealthGPTAppDelegate.swift`.


  ## :white_check_mark: Testing

  - Complete onboarding and verify the HealthKit permission dialog now includes
  "Resting Heart Rate"
  - Ask the LLM about resting heart rate and confirm it returns actual values
  instead of 0 or "Data doesn't exist"


  ### Code of Conduct & Contributing Guidelines
  By creating and submitting this pull request, you agree to follow our [Code of

  Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md)
   and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/ma
  in/CONTRIBUTING.md):
  - [x] I agree to follow the [Code of
  Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md)
   and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/ma
  in/CONTRIBUTING.md).
