### PR TITLE
Add starter query suggestions for empty chat screen

### DIFF
--- a/HealthGPT/HealthGPT/HealthGPTView.swift
+++ b/HealthGPT/HealthGPT/HealthGPTView.swift
@@ -29,6 +29,7 @@ struct HealthGPTView: View {
     @State private var modelSettingRefreshId = UUID()
     @State private var messageTaskId = 0
 
+<<<<<<< Updated upstream
     var body: some View {
         NavigationStack {
             if let llm = self.healthDataInterpreter.llm {
@@ -66,6 +67,20 @@ struct HealthGPTView: View {
             } else {
                 self.loadingChatView
             }
+=======
+    /// Whether the chat has no user or assistant messages yet.
+    /// Controls visibility of the suggestion banner overlay.
+    private var isChatEmpty: Bool {
+        guard let llm = healthDataInterpreter.llm else {
+            return true
+        }
+        return !llm.context.chat.contains(where: { $0.role == .user || $0.role == .assistant })
+    }
+
+    var body: some View {
+        NavigationStack {
+            chatViewContent
+>>>>>>> Stashed changes
         }
         .sheet(isPresented: $showSettings) {
             SettingsView(modelSettingRefreshId: $modelSettingRefreshId)
@@ -95,6 +110,53 @@ struct HealthGPTView: View {
         }
     }
     
+    @ViewBuilder private var chatViewContent: some View {
+        if let llm = self.healthDataInterpreter.llm {
+            let contextBinding = Binding { llm.context.chat } set: { llm.context.chat = $0 }
+            ZStack {
+                ChatView(contextBinding, exportFormat: .text)
+                    .speak(llm.context.chat, muted: !self.textToSpeech)
+                    .speechToolbarButton(muted: !self.$textToSpeech)
+                if isChatEmpty {
+                    VStack {
+                        Spacer()
+                        SuggestionBannerView { suggestion in
+                            contextBinding.wrappedValue.append(ChatEntity(role: .user, content: suggestion))
+                        }
+                        .padding(.bottom, 70)
+                    }
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.3), value: isChatEmpty)
+                }
+            }
+            .viewStateAlert(state: llm.state)
+            .navigationTitle("WELCOME_TITLE")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    self.settingsButton
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    self.resetChatButton
+                }
+            }
+            .onChange(of: llm.context, initial: true) { _, _ in
+                if !llm.context.isEmpty && llm.state != .generating && llm.context.last?.role != .system {
+                    self.messageTaskId += 1
+                }
+            }
+            .task(id: self.messageTaskId) {
+                do {
+                    try await healthDataInterpreter.queryLLM()
+                } catch {
+                    showErrorAlert = true
+                    errorMessage = "Error querying LLM: \(error.localizedDescription)"
+                }
+            }
+        } else {
+            self.loadingChatView
+        }
+    }
+
     private var settingsButton: some View {
         Button(
             action: {

--- a/HealthGPT/HealthGPT/SuggestionBannerView.swift
+++ b/HealthGPT/HealthGPT/SuggestionBannerView.swift
@@ -1,0 +1,92 @@
+//
+// This source file is part of the Stanford HealthGPT project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University & Project Contributors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+/// A banner view that displays rotating sample query suggestions.
+/// Tapping a suggestion triggers the `onSuggestionTapped` callback.
+/// The suggestion automatically cycles every 10 seconds with a fade animation.
+struct SuggestionBannerView: View {
+    /// Callback invoked when the user taps a suggestion. Passes the query string.
+    let onSuggestionTapped: (String) -> Void
+
+    /// The currently displayed suggestion text.
+    @State private var currentSuggestion: String = SampleQueries.random()
+
+    /// Controls the opacity for the fade-in/fade-out cycling animation.
+    @State private var opacity: Double = 1.0
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // "Try asking:" label
+            Text("SUGGESTION_PREFIX")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            // The tappable suggestion pill/card
+            Button {
+                onSuggestionTapped(currentSuggestion)
+            } label: {
+                Text(currentSuggestion)
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(.systemGray6))
+                    )
+                    .foregroundStyle(.primary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("suggestionBanner")
+            .accessibilityHint(Text("SUGGESTION_ACCESSIBILITY_HINT"))
+        }
+        .opacity(opacity)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+        .task {
+            // Cycle suggestions every 10 seconds with fade animation
+            await cycleSuggestions()
+        }
+    }
+
+    /// Continuously cycles through suggestions with a fade-out → swap → fade-in animation.
+    /// This async function runs for the lifetime of the view and auto-cancels on disappear.
+    @MainActor
+    private func cycleSuggestions() async {
+        while !Task.isCancelled {
+            // Wait 10 seconds before cycling
+            try? await Task.sleep(for: .seconds(7))
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            // Phase 1: Fade out (0.4s)
+            withAnimation(.easeInOut(duration: 0.6)) {
+                opacity = 0.0
+            }
+
+            // Wait for fade-out to complete
+            try? await Task.sleep(for: .milliseconds(600))
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            // Phase 2: Swap the text (while invisible)
+            currentSuggestion = SampleQueries.random(excluding: currentSuggestion)
+
+            // Phase 3: Fade in (0.4s)
+            withAnimation(.easeInOut(duration: 0.6)) {
+                opacity = 1.0
+            }
+        }
+    }
+}


### PR DESCRIPTION
✧ When the chat is empty, display tappable example prompts so first-time users see what kinds of questions HealthGPT can answer. Suggestions disappear once the conversation has any messages.

✧ Closes #24

✧ Signed-off-by: Ehan Shah <ehanrsha@gmail.com>

✧ Created A Video Demonstrating The Addition -> https://drive.google.com/file/d/1QnNQ4cw0hT9HTUWk4DZHG_FmUZxRZUuQ/view?usp=sharing