### PR TITLE
 Fixed incorrect AppDelegate file path in README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Building and running HealthGPT requires a Mac with [Xcode 16.2](https://develope
 
 You can add queries for additional [HealthKit](https://developer.apple.com/documentation/healthkit) quantities and categories as follows:
 
-1. Update the SpeziHealthKit configuration in [`HealthGPT/HealthGPT/AppDelegate.swift`](https://github.com/StanfordBDHG/HealthGPT/blob/main/HealthGPT/HealthGPTAppDelegate.swift) to include the additional data type(s). For more information about configuring SpeziHealthKit, please refer to the [official documentation](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit/0.5.3/documentation/spezihealthkit).
+1. Update the SpeziHealthKit configuration in [`HealthGPT/HealthGPTAppDelegate.swift`](https://github.com/StanfordBDHG/HealthGPT/blob/main/HealthGPT/HealthGPTAppDelegate.swift) to include the additional data type(s). For more information about configuring SpeziHealthKit, please refer to the [official documentation](https://swiftpackageindex.com/StanfordSpezi/SpeziHealthKit/0.5.3/documentation/spezihealthkit).
 2. Edit [`HealthGPT/HealthGPT/HealthDataFetcher.swift`](https://github.com/StanfordBDHG/HealthGPT/blob/main/HealthGPT/HealthGPT/HealthDataFetcher.swift) to create appropriate query for your data type(s).
 3. Update the prompt in [`HealthGPT/HealthGPT/PromptGenerator.swift`](https://github.com/StanfordBDHG/HealthGPT/blob/main/HealthGPT/HealthGPT/PromptGenerator.swift) to pass the newly acquired data to the OpenAI API.
 


### PR DESCRIPTION
The README's Set Up section showed the path HealthGPT/HealthGPT/AppDelegate.swift, but the actual file is HealthGPT/HealthGPTAppDelegate.swift (which the link's URL already points to). Updated the displayed text to match.

# *Name of the PR*

## :recycle: Current situation & Problem
*Link any open issues or pull requests (PRs) related to this PR. Please ensure that all non-trivial PRs are first tracked and discussed in an existing GitHub issue or discussion.*


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
